### PR TITLE
fix: game 관련 응답 정형화

### DIFF
--- a/src/main/java/store/warab/controller/CategoryController.java
+++ b/src/main/java/store/warab/controller/CategoryController.java
@@ -1,5 +1,7 @@
 package store.warab.controller;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -7,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import store.warab.common.util.ApiResponse;
 import store.warab.dto.CategoryListResponseDto;
 import store.warab.service.CategoryService;
 
@@ -20,8 +23,8 @@ public class CategoryController {
 
   // 모든 카테고리 조회
   @GetMapping
-  public ResponseEntity<Set<CategoryListResponseDto>> getAllCategories() {
-    Set<CategoryListResponseDto> result =
+  public ResponseEntity<ApiResponse> getAllCategories() {
+    Set<CategoryListResponseDto> categorys =
         categoryService.getAllCategories().stream()
             .map(
                 category ->
@@ -29,7 +32,8 @@ public class CategoryController {
                         category.getId(), // id가 gameId가 아니라면 변수명도 맞게 수정
                         category.getCategoryName()))
             .collect(Collectors.toSet());
-
-    return ResponseEntity.ok(result);
+    Map<String, Object> data = new HashMap<>();
+    data.put("categorys", categorys);
+    return ResponseEntity.ok(new ApiResponse("category_list_inquiry_success", data));
   }
 }

--- a/src/main/java/store/warab/controller/CommentController.java
+++ b/src/main/java/store/warab/controller/CommentController.java
@@ -16,17 +16,17 @@ public class CommentController {
     this.commentService = commentService;
   }
 
-  /** [POST] /api/comment 새 댓글 생성 */
+  /** [POST] /api/v1/comment 새 댓글 생성 */
   @PostMapping
   public Comment createComment(@RequestBody CommentRequest request) {
     return commentService.createComment(
         request.getUserId(), request.getGameId(), request.getContent());
   }
 
-  /** [GET] /api/comments/game/{gameId} 특정 게임에 달린 댓글 목록 */
-  @GetMapping("/{game}/{gameId}")
+  /** [GET] /api/v1/comment/game/{gameId} 특정 게임에 달린 댓글 목록 */
+  @GetMapping("/game/{gameId}")
   public List<Comment> getCommentsByGame(
-      @PathVariable Integer gameId, @PathVariable String nickname) {
+      @PathVariable Integer gameId) {
     return commentService.getCommentsByGameId(gameId);
   }
 

--- a/src/main/java/store/warab/controller/GameController.java
+++ b/src/main/java/store/warab/controller/GameController.java
@@ -1,9 +1,12 @@
 package store.warab.controller;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import store.warab.common.util.ApiResponse;
 import store.warab.dto.GameDetailResponseDto;
 import store.warab.dto.GameSearchResponseDto;
 import store.warab.service.GameService;
@@ -18,14 +21,16 @@ public class GameController {
     this.gameService = gameService;
   }
 
+  ///api/v1/games/{id}
   @GetMapping("/{id}")
-  public ResponseEntity<GameDetailResponseDto> getGameDetail(@PathVariable Long id) {
-    GameDetailResponseDto gameDetail = gameService.getGameDetail(id);
-    return ResponseEntity.ok(gameDetail);
+  public ResponseEntity<ApiResponse> getGameDetail(@PathVariable Long id) {
+    GameDetailResponseDto data = gameService.getGameDetail(id);
+    return ResponseEntity.ok(new ApiResponse("game_detail_info_inquiry_success", data));
   }
 
+///api/v1/games
   @GetMapping
-  public List<GameSearchResponseDto> getFilteredGames(
+  public ResponseEntity<ApiResponse> getFilteredGames(
       @RequestParam(required = false) String query,
       @RequestParam(required = false) Set<Long> category_ids,
       @RequestParam(required = false) Integer rating_min,
@@ -39,19 +44,22 @@ public class GameController {
       @RequestParam(required = false) String mode,
       @RequestParam(required = false) String sort,
       @RequestParam(required = false) Integer limit) {
-    return gameService.filterGames(
-        query,
-        category_ids,
-        rating_min,
-        rating_max,
-        price_min,
-        price_max,
-        players_min,
-        players_max,
-        online_players_min,
-        online_players_max,
-        mode,
-        sort,
-        limit);
+      List<GameSearchResponseDto> games = gameService.filterGames(
+          query,
+          category_ids,
+          rating_min,
+          rating_max,
+          price_min,
+          price_max,
+          players_min,
+          players_max,
+          online_players_min,
+          online_players_max,
+          mode,
+          sort,
+          limit);
+        Map<String, Object> data = new HashMap<>();
+        data.put("games", games);
+      return ResponseEntity.ok(new ApiResponse("game_list_inquiry_success", data));
   }
 }

--- a/src/main/java/store/warab/dto/GameSearchResponseDto.java
+++ b/src/main/java/store/warab/dto/GameSearchResponseDto.java
@@ -8,14 +8,14 @@ import store.warab.entity.GameStatic;
 @Getter
 @Setter
 public class GameSearchResponseDto {
-  private Long id;
+  private Long game_id;
   private String title;
   private String thumbnail;
   private Integer price;
   private Integer lowest_price;
 
   public GameSearchResponseDto(GameStatic gameStatic, GameDynamic gameDynamic) {
-    this.id = gameStatic.getId();
+    this.game_id = gameStatic.getId();
     this.title = gameStatic.getTitle();
     this.thumbnail = gameStatic.getThumbnail();
     this.price = gameStatic.getPrice();

--- a/src/main/java/store/warab/entity/GameDynamic.java
+++ b/src/main/java/store/warab/entity/GameDynamic.java
@@ -15,7 +15,7 @@ public class GameDynamic {
 
   private Integer rating;
   private Integer active_players;
-  private String lowest_platform;
+  private Integer lowest_platform;
   private Integer lowest_price;
   private Integer history_lowest_Price;
   private LocalDateTime updated_at;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,7 +26,7 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 
 # JPA
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=validate
 #debug
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-application.version=0.2.0-SNAPSHOT
+application.version=0.1.0-SNAPSHOT


### PR DESCRIPTION
fix: game 관련 응답 정형화

### Description

200번대 응답시 단순히 dto 객체만을 보내는게 아닌 api 명세서에 맞춰 message와 함께 data객체에 감싸 응답하도록 변경.

### Changes Made

1. GameController에서 응답 방식 정형화. 이후 참고하여 다른 controller에도 변경 필요.
2. 댓글 조회의 경로와 인자가 잘못되어 있어 수정.


### Testing

postman으로 정상 요청 시 정상 응답이 api 명세서 대로 오는 것을 확인. 추가적인 예외처리 필요.

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.
