### PR TITLE
fix: userProfile 조회 응답 명세서 따라 api, ResponseDto 수정

### DIFF
--- a/src/main/java/store/warab/controller/UserController.java
+++ b/src/main/java/store/warab/controller/UserController.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import store.warab.common.util.ApiResponse;
-import store.warab.dto.UserDto;
+import store.warab.dto.UserProfileResponseDto;
 import store.warab.dto.UserProfileUpdateRequest;
 import store.warab.service.AuthService;
 import store.warab.service.DiscordService;
@@ -31,9 +31,9 @@ public class UserController {
   @GetMapping("/profile")
   public ResponseEntity<ApiResponse> getProfile(@CookieValue("jwt") String token) {
     Long tokenUserId = authService.extractUserId(token);
-    UserDto userDto = userService.getUserById(tokenUserId);
+    UserProfileResponseDto userProfileResponseDto = userService.getUserById(tokenUserId);
 
-    return ResponseEntity.ok(new ApiResponse("user_profile_inquiry_success", userDto));
+    return ResponseEntity.ok(new ApiResponse("user_profile_inquiry_success", userProfileResponseDto));
   }
 
   // 닉네임 중복 확인

--- a/src/main/java/store/warab/dto/UserProfileResponseDto.java
+++ b/src/main/java/store/warab/dto/UserProfileResponseDto.java
@@ -1,6 +1,8 @@
 package store.warab.dto;
 
 import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,14 +12,16 @@ import store.warab.entity.User;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-public class UserDto {
-  private Long id;
+public class UserProfileResponseDto {
   private String nickname;
+
+    @JsonProperty("discord_link")
   private String discordLink;
+
   private Set<Category> categories;
 
-  public static UserDto fromEntity(User user) {
-    return new UserDto(
-        user.getId(), user.getNickname(), user.getDiscordLink(), user.getCategories());
+  public static UserProfileResponseDto fromEntity(User user) {
+    return new UserProfileResponseDto(
+        user.getNickname(), user.getDiscordLink(), user.getCategories());
   }
 }

--- a/src/main/java/store/warab/entity/Category.java
+++ b/src/main/java/store/warab/entity/Category.java
@@ -1,5 +1,6 @@
 package store.warab.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,5 +16,6 @@ public class Category {
   private Long id;
 
   @Column(name = "category_name", nullable = false, length = 100)
+  @JsonProperty("category_name")
   private String categoryName;
 }

--- a/src/main/java/store/warab/service/UserService.java
+++ b/src/main/java/store/warab/service/UserService.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
-import store.warab.dto.UserDto;
+import store.warab.dto.UserProfileResponseDto;
 import store.warab.dto.UserProfileUpdateRequest;
 import store.warab.entity.Category;
 import store.warab.entity.User;
@@ -23,7 +23,7 @@ public class UserService {
   private final CategoryRepository categoryRepository;
   private final DiscordService discordService;
 
-  public UserDto getUserById(long userId) {
+  public UserProfileResponseDto getUserById(long userId) {
     User user =
         userRepository
             .findById(userId)
@@ -31,7 +31,7 @@ public class UserService {
                 () ->
                     new ResponseStatusException(
                         HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다" + userId) {});
-    return UserDto.fromEntity(user);
+    return UserProfileResponseDto.fromEntity(user);
   }
 
   public boolean isNicknameDuplicated(String nickname) {

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-application.version=0.1.1-SNAPSHOT
+application.version=0.1.0-SNAPSHOT


### PR DESCRIPTION
fix: userProfile 조회 응답 명세서 따라 api, ResponseDto 수정

### Description

응답으로 줄 필요없는 userId를 주고 있어 삭제.
카테고리 id뿐 아니라 이름과 함께 응답하도록 수정.

