### PR TITLE
comment 목록 조회 api 명세서에 맞게 수정

### DIFF
--- a/src/main/java/store/warab/controller/CommentController.java
+++ b/src/main/java/store/warab/controller/CommentController.java
@@ -8,7 +8,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import store.warab.common.util.ApiResponse;
 import store.warab.dto.CommentRequest;
+import store.warab.dto.CommentResponseDto;
 import store.warab.entity.Comment;
+import store.warab.entity.User;
 import store.warab.service.AuthService;
 import store.warab.service.CommentService;
 
@@ -42,7 +44,7 @@ public class CommentController {
   /** [GET] /api/v1/games/{gameId}/comment 특정 게임에 달린 댓글 목록 */
   @GetMapping("/{gameId}/comment")
   public ResponseEntity<ApiResponse> getCommentsByGame(@PathVariable Integer gameId) {
-    List<Comment> comments = commentService.getCommentsByGameId(gameId);
+      List<CommentResponseDto>  comments = commentService.getCommentDtosByGameId(gameId);
     Map<String, Object> data = new HashMap<>();
     data.put("comments", comments);
     return ResponseEntity.ok(new ApiResponse("comment_list inquiry_success", data));

--- a/src/main/java/store/warab/dto/CommentResponseDto.java
+++ b/src/main/java/store/warab/dto/CommentResponseDto.java
@@ -1,0 +1,41 @@
+package store.warab.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import store.warab.entity.Comment;
+import store.warab.entity.User;
+
+import java.time.LocalDateTime;
+
+
+public class CommentResponseDto {
+    @JsonProperty("comment_id")
+    private Long commentId;
+
+    @JsonProperty("user_id")
+    private Long userId;
+
+    @JsonProperty("name")
+    private String nickName;
+
+    @JsonProperty("content")
+    private String content;
+
+    @JsonProperty("created_at")
+    private LocalDateTime createdAt;
+
+    @JsonProperty("updated_at")
+    private LocalDateTime updatedAt;
+
+    @JsonProperty("deleted_at")
+    private LocalDateTime deletedAt;
+
+    public CommentResponseDto(User user, Comment comment) {
+        this.commentId = comment.getCommentId();
+        this.userId = user.getId();
+        this.nickName = user.getNickname();
+        this.content = comment.getContent();
+        this.createdAt = comment.getCreatedAt();
+        this.updatedAt = comment.getUpdatedAt();
+        this.deletedAt = comment.getDeletedAt();
+    }
+}

--- a/src/main/java/store/warab/service/CommentService.java
+++ b/src/main/java/store/warab/service/CommentService.java
@@ -1,19 +1,26 @@
 package store.warab.service;
 
 import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import store.warab.dto.CommentResponseDto;
 import store.warab.entity.Comment;
+import store.warab.entity.User;
 import store.warab.repository.CommentRepository;
+import store.warab.repository.UserRepository;
 
 @Service
 @Transactional
 public class CommentService {
 
   private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
 
-  public CommentService(CommentRepository commentRepository) {
+    public CommentService(CommentRepository commentRepository, UserRepository userRepository) {
     this.commentRepository = commentRepository;
+        this.userRepository = userRepository;
   }
 
   // 댓글 작성
@@ -33,6 +40,20 @@ public class CommentService {
     return commentRepository.findByGameId(gameId);
   }
 
+    public List<CommentResponseDto> getCommentDtosByGameId(Integer gameId)
+    {
+        List<Comment> comments = commentRepository.findByGameId(gameId);
+        return comments.stream()
+            .map(comment -> {
+                User user = userRepository.findById(comment.getUserId())
+                    .orElseThrow(() -> new RuntimeException("User not found"));
+                return new CommentResponseDto(
+                    user,comment
+                );
+            })
+            .collect(Collectors.toList());
+
+    }
   // 특정 댓글
   @Transactional(readOnly = true)
   public Comment getComment(Integer commentId) {

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-application.version=0.1.1-SNAPSHOT
+application.version=0.1.0-SNAPSHOT


### PR DESCRIPTION
fix: comment 조회 api 명세서에 맞게 수정

### Description

기존에 comment 객체를 그대로 보내고 있었는데 필요한 user정보 추가하고 응답할 필요없는 정보 빼서 응답 하도록 수정.
