### PR TITLE
fix: 회원정보 수정 - 닉네임 null/공백 방지, 선호 카테고리 비우기 허용

### DIFF
--- a/src/main/java/store/warab/controller/UserController.java
+++ b/src/main/java/store/warab/controller/UserController.java
@@ -1,6 +1,7 @@
 package store.warab.controller;
 
 // import java.lang.classfile.constantpool.StringEntry;
+import jakarta.validation.Valid;
 import java.util.Map;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -72,7 +73,7 @@ public class UserController {
   //    /api/v1/users/profile
   @PutMapping("/profile")
   public ResponseEntity<ApiResponse> updateProfile(
-      @RequestBody UserProfileUpdateRequest dto, @CookieValue("jwt") String token) {
+      @Valid @RequestBody UserProfileUpdateRequest dto, @CookieValue("jwt") String token) {
     Long tokenUserId = authService.extractUserId(token);
 
     userService.updateUserInfo(dto, tokenUserId);

--- a/src/main/java/store/warab/dto/UserProfileUpdateRequest.java
+++ b/src/main/java/store/warab/dto/UserProfileUpdateRequest.java
@@ -1,6 +1,7 @@
 package store.warab.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,11 +13,13 @@ import lombok.Setter;
 @Getter
 @Setter
 public class UserProfileUpdateRequest {
+  @NotNull(message = "nickname is required")
   private String nickname;
 
   @JsonProperty("discord")
   private String discordLink;
 
   @JsonProperty("category")
+  @NotNull(message = "category is required")
   private Set<Long> categoryIds;
 }

--- a/src/main/java/store/warab/service/UserService.java
+++ b/src/main/java/store/warab/service/UserService.java
@@ -65,9 +65,15 @@ public class UserService {
                 () ->
                     new ResponseStatusException(HttpStatus.NOT_FOUND, "유저가 존재하지 않습니다: " + userId));
 
+    // 닉네임의 양 옆 공백 제거
+    request.setNickname(request.getNickname().trim());
+
+    if (request.getNickname().isEmpty()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "닉네임은 공백으로 이루어질 수 없습니다.");
+    }
     // 닉네임 중복 검사
-    if (!user.getNickname().equals(request.getNickname())
-        && isNicknameDuplicated(request.getNickname())) {
+    if ((!user.getNickname().equals(request.getNickname())
+        && isNicknameDuplicated(request.getNickname()))) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임입니다.");
     }
 
@@ -88,7 +94,9 @@ public class UserService {
     user.setDiscordLink(request.getDiscordLink());
 
     // 카테고리 ID 검증 및 설정
-    if (request.getCategoryIds() != null && !request.getCategoryIds().isEmpty()) {
+    if (request.getCategoryIds().isEmpty()) {
+      user.setCategories(null);
+    } else { // Bean Validation 사용하여 null check 생략 가능.
       Set<Long> validCategoryIds =
           categoryRepository.findValidCategoryIds(request.getCategoryIds());
       Set<Category> preferredCategories =


### PR DESCRIPTION
### Description

회원정보update - 닉네임에 null, 공백 들어가는 이슈, 선호 카테고리 비우기 가능하도록 수정.

### Related Issues

#3 

### Additional Notes

닉네임에 띄어쓰기 허용되는지 논의 필요.
