### PR TITLE
fix: 존재하지 않는 게임에도 댓글 작성 결과 반환 - 200 -> 404 error

### DIFF
--- a/src/main/java/store/warab/service/CommentService.java
+++ b/src/main/java/store/warab/service/CommentService.java
@@ -8,24 +8,35 @@ import store.warab.common.exception.ForbiddenException;
 import store.warab.common.exception.NotFoundException;
 import store.warab.dto.CommentResponseDto;
 import store.warab.entity.Comment;
+import store.warab.entity.GameStatic;
 import store.warab.entity.User;
 import store.warab.repository.CommentRepository;
+import store.warab.repository.GameStaticRepository;
 import store.warab.repository.UserRepository;
 
 @Service
 @Transactional
 public class CommentService {
-
+  private final GameStaticRepository gameStaticRepository;
   private final CommentRepository commentRepository;
   private final UserRepository userRepository;
 
-  public CommentService(CommentRepository commentRepository, UserRepository userRepository) {
+  public CommentService(
+      GameStaticRepository gameStaticRepository,
+      CommentRepository commentRepository,
+      UserRepository userRepository) {
+    this.gameStaticRepository = gameStaticRepository;
     this.commentRepository = commentRepository;
     this.userRepository = userRepository;
   }
 
   // 댓글 작성
   public Comment createComment(Long userId, Long gameId, String content) {
+    GameStatic game_static =
+        gameStaticRepository
+            .findById(gameId)
+            .orElseThrow(() -> new NotFoundException("게임이 존재하지 않습니다."));
+
     // userId, gameId 검증(존재 여부 등)은 추후 실제 User, Game 매핑 후에 처리
     Comment comment = new Comment();
     comment.setUserId(userId);

--- a/src/main/java/store/warab/service/GameService.java
+++ b/src/main/java/store/warab/service/GameService.java
@@ -173,11 +173,16 @@ public class GameService {
     return result;
   }
 
-  public GameLowestPriceDto getLowestPrice(Long id) {
+  public GameLowestPriceDto getLowestPrice(Long gameId) {
+    GameStatic game_static =
+        gameStaticRepository
+            .findById(gameId)
+            .orElseThrow(() -> new NotFoundException("게임이 존재하지 않습니다."));
+
     GameDynamic gameDynamic =
         gameDynamicRepository
-            .findById(id)
-            .orElseThrow(() -> new NotFoundException("게임이 존재하지 않습니다."));
+            .findById(gameId)
+            .orElseThrow(() -> new NotFoundException("해당 게임의 동적 정보가 존재하지 않습니다."));
     return new GameLowestPriceDto(gameDynamic);
   }
 }

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-application.version=0.1.1-SNAPSHOT
+application.version=0.1.0-SNAPSHOT


### PR DESCRIPTION
### Description

존재하지 않는 게임에 대해 댓글 작성 막고 에러처리.

### Related Issues

- Resolves wiki issue #16

### Changes Made

1. gameId를 확인하고 해당 id에 해당하는 게임을 찾을 수 없는 경우 에러처리.
2. 추가로 역대 최저가 조회 에러에 대해 static, dynamic으로 나누어 처리.

### Checklist

- [X] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [X] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [X] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [X] 코드 스타일 가이드라인을 준수했습니다.
- [X] 코드 리뷰어를 지정했습니다.

