### PR TITLE
fix: pre-commit에서 spotless 적용시 이미 staging area에 올라온 파일들만이 다시 add 되도록 수정

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,5 +1,25 @@
  #!/bin/sh
 
+echo "🔧 Spotless 검사 중..."
+
+# 현재 스테이징된 Java 파일만 추출
+STAGED=$(git diff --cached --name-only --diff-filter=ACM | grep '\.java$')
+
+
+if [ -n "$STAGED" ]; then
+  ./gradlew spotlessCheck > /dev/null 2>&1
+
+  if [ $? -ne 0 ]; then
+    echo "⚠️ 포맷팅이 맞지 않아 자동으로 수정합니다..."
+    ./gradlew spotlessApply
+
+    echo "$STAGED" | xargs git add
+
+    echo "✅ 수정 완료. 다시 커밋해주세요."
+    exit 1
+  fi
+fi
+
  echo "🔍 Running pre-commit hook..."
 
  # 테스트 실행 (선택)
@@ -8,13 +28,5 @@
      echo "❌ Tests failed! Fix the issues before committing."
      exit 1
  fi
-
- ./gradlew spotlessApply build
- if [ $? -ne 0 ]; then
-     echo "❌ Checkstyle failed! Fix the issues before committing."
-     exit 1
- fi
-
- echo "✅ pre-commit checks passed!"
-
  exit 0
+

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-application.version=0.1.1-SNAPSHOT
+application.version=0.1.0-SNAPSHOT


### PR DESCRIPTION
### Description

기존에는 pre-commit에서 단순 untracked, modifiled file들에 spotless가 로컬에서 적용되고 commit되는 파일들에는 적용되지 않아 막상 push되는 파일들에는 spotless가 적용되지 않는 경우 발생. -> 다시 add하고자 git status를 확인해보더라도 작업한 파일 외의 모든 파일들에 spotless가 적용되어 작업했던 file들만을 일일이 찾아 add하는데에 어려움이 있었음. -> 이미 staging area에 올라온 파일들만이 다시 add 되도록 수정하고 commit을 취소시키고 다시 commit하도록 해 해결.